### PR TITLE
Update canto34.js

### DIFF
--- a/src/canto34.js
+++ b/src/canto34.js
@@ -166,6 +166,7 @@ class Lexer {
 
 				remaining = remaining.substring(consumed.length);
 				tracker.consume(consumed);
+				break; //This break is needed as we need to start matching from top of tokenType list
 
 			}
 


### PR DESCRIPTION
Fixed bug where successive tokens not matched  with different token type

There was bug in tokenisation process. After matching for one specific token, next token was not matching again first token type listed, instead it was matching to subsequent tokens in the list.